### PR TITLE
Make picoruby also build at build time without running install.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ add_custom_target(
   mrbdir ALL
   COMMAND ${CMAKE_COMMAND} -E make_directory ${COMPONENT_DIR}/mrb
 )
-add_dependencies(${COMPONENT_LIB} mrbdir)
+add_dependencies(mrbdir picoruby)
 
 set(RUBY_FILES main_task)
 set(PICORBC ${COMPONENT_DIR}/picoruby/bin/picorbc)
@@ -63,7 +63,8 @@ add_custom_target(${rb}
   COMMAND ${PICORBC} -B${rb} -o${COMPONENT_DIR}/mrb/${rb}.c ${COMPONENT_DIR}/mrblib/${rb}.rb
   DEPENDS mrbdir
 )
+add_dependencies(${rb} picoruby)
 endforeach(rb)
 
 add_custom_target(generate_files ALL DEPENDS mrbdir ${RUBY_FILES})
-add_dependencies(${COMPONENT_LIB} generate_files)
+add_dependencies(generate_files picoruby)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,6 @@ $ git submodule add https://github.com/picoruby/picoruby-esp32.git components/pi
 
 ### Setup
 
-Run the following shell script to build PicoRuby:
-
-```sh
-$ ./components/picoruby-esp32/install.sh
-```
-
 Open your `main/CMakeLists.txt` file in an editor. Add `picoruby-esp32` to the `REQUIRES` field.
 
 ```cmake

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Prepare your project by referring to [this page](https://docs.espressif.com/proj
 Clone this repository into the `components` directory of your project using Git Submodule.
 
 ```sh
-$ git submodule add https://github.com/yuuu/picoruby-esp32.git components/picoruby-esp32
+$ git submodule add https://github.com/picoruby/picoruby-esp32.git components/picoruby-esp32
 ```
 
 ### Setup
@@ -81,4 +81,4 @@ Currently, this project is tested in the following environment only:
 
 ## License
 
-[picoruby-esp32](https://github.com/yuuu/picoruby-esp32) is released under the [MIT License](https://github.com/yuuu/picoruby-esp32/blob/main/LICENSE).
+[picoruby-esp32](https://github.com/picoruby/picoruby-esp32) is released under the [MIT License](https://github.com/picoruby/picoruby-esp32/blob/master/LICENSE).

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 version: "0.0.2"
 description: "This component for ESP-IDF builds the open-source software PicoRuby into a static library, allowing you to link it and run PicoRuby seamlessly on their microcontroller boards."
-url: "https://github.com/yuuu/picoruby-esp32"
-issues: "https://github.com/yuuu/picoruby-esp32/issues"
-repository: "https://github.com/yuuu/picoruby-esp32.git"
+url: "https://github.com/picoruby/picoruby-esp32"
+issues: "https://github.com/picoruby/picoruby-esp32/issues"
+repository: "https://github.com/picoruby/picoruby-esp32.git"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-
-SCRIPT_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
-cd $SCRIPT_DIR
-cd picoruby
-rake


### PR DESCRIPTION
- Replace some urls for repository.
- Make picoruby also build at build time without running install.sh.
