### PR TITLE
Add Timer to picoruby-machine for ESP32 to make task READY.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,11 @@ idf_component_register(
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-mrubyc/lib/mrubyc/src
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-machine/include
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-filesystem-fat/ports/esp32
-  REQUIRES esp_driver_uart spi_flash
-  PRIV_REQUIRES esp_driver_gpio
+  PRIV_REQUIRES
+    esp_driver_gpio
+    esp_timer
+    esp_driver_uart
+    spi_flash
 )
 
 add_definitions(

--- a/mrblib/main_task.rb
+++ b/mrblib/main_task.rb
@@ -6,35 +6,31 @@ STDOUT = IO
 
 # Setup flash disk
 begin
-  Machine.using_delay do
-    STDIN.echo = false
-    $shell = Shell.new(clean: true)
+  STDIN.echo = false
+  $shell = Shell.new(clean: true)
 
-    puts "Initializing FLASH disk as the root volume... "
-    $shell.setup_root_volume(:flash, label: 'storage')
-    $shell.setup_system_files
-    puts "Available"
-  end
+  puts "Initializing FLASH disk as the root volume... "
+  $shell.setup_root_volume(:flash, label: 'storage')
+  $shell.setup_system_files
+  puts "Available"
 rescue => e
   puts "Not available"
   puts "#{e.message} (#{e.class})"
 end
 
 begin
-  Machine.using_delay do
-    if File.exist?("/home/app.mrb")
-      puts "Loading app.mrb"
-      load "/home/app.mrb"
-    elsif File.exist?("/home/app.rb")
-      puts "Loading app.rb"
-      load "/home/app.rb"
-    end
-
-    puts "Starting shell...\n\n"
-    
-    $shell.show_logo
-    $shell.start
+  if File.exist?("/home/app.mrb")
+    puts "Loading app.mrb"
+    load "/home/app.mrb"
+  elsif File.exist?("/home/app.rb")
+    puts "Loading app.rb"
+    load "/home/app.rb"
   end
+
+  puts "Starting shell...\n\n"
+
+  $shell.show_logo
+  $shell.start
 rescue => e
   puts "#{e.message} (#{e.class})"
 end


### PR DESCRIPTION
Add `esp_timer` to correspond to https://github.com/picoruby/picoruby/pull/198.

With this, we no longer need to use `Machine.using_delay`.