### PR TITLE
Update PicoRuby.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ idf_component_register(
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-rmt/ports/esp32/rmt.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-watchdog/ports/esp32/watchdog.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-mbedtls/ports/esp32/timing_alt.c
+    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-i2c/ports/esp32/i2c.c
+    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-uart/ports/esp32/uart.c
   INCLUDE_DIRS
     ${COMPONENT_DIR}
     ${COMPONENT_DIR}/picoruby/include
@@ -31,6 +33,7 @@ idf_component_register(
     esp_timer
     esp_hw_support
     spi_flash
+    driver
 )
 
 add_definitions(


### PR DESCRIPTION
includes
- https://github.com/picoruby/picoruby/pull/218
  - I have already confirmed that run example usage.
- https://github.com/picoruby/picoruby/pull/220
  - I have already confirmed ↓ to be called without errors

```
require 'uart'
uart = UART.new(unit: 'ESP32_UART1', txd_pin: 19, rxd_pin: 18)
```
