### PR TITLE
Replace driver with esp_driver_i2c.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,11 @@ idf_component_register(
     esp_driver_spi
     esp_driver_ledc
     esp_driver_rmt
+    esp_driver_i2c
     esp_adc
     esp_timer
     esp_hw_support
     spi_flash
-    driver
 )
 
 add_definitions(


### PR DESCRIPTION
Since we are trying to specify them individually, we will change them to use esp_driver_i2c.
#17 