### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # PicoRuby on ESP32
 
+> [!IMPORTANT]
+> **This repository has been archived.**
+>
+> - This repository has been merged into [picoruby/R2P2-ESP32](https://github.com/picoruby/R2P2-ESP32).
+> - The repository itself will remain available for those who want to incorporate PicoRuby as a library with ESP-IDF.
+
 This is a component that can be used with ESP-IDF, allowing you to add [PicoRuby](https://github.com/picoruby/picoruby) to your project.
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- Add an archive notice to the top of README.md announcing that this repository has been merged into [picoruby/R2P2-ESP32](https://github.com/picoruby/R2P2-ESP32)
- Note that the repository itself will remain available for those who want to incorporate PicoRuby as a library with ESP-IDF

## Test plan
- [ ] Verify the rendered notice appears correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)